### PR TITLE
Support "data-" and "aria-" attributes in PathLink component

### DIFF
--- a/src/components/PathLink.tsx
+++ b/src/components/PathLink.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
 import { useRouter } from '../context/RouterContext';
 
-interface PathLinkProps {
+type PathLinkProps = {
   to: string;
   children: React.ReactNode;
   className?: string;
-}
+} & React.AriaAttributes;
 
 // We use ...restProps to pass "data-" and "aria-" attributes
 export function PathLink({

--- a/src/components/PathLink.tsx
+++ b/src/components/PathLink.tsx
@@ -7,7 +7,13 @@ interface PathLinkProps {
   className?: string;
 }
 
-export function PathLink({ to, children, className }: PathLinkProps) {
+// We use ...restProps to pass "data-" and "aria-" attributes
+export function PathLink({
+  to,
+  children,
+  className,
+  ...restProps
+}: PathLinkProps) {
   const { history } = useRouter();
 
   const handleClick = useCallback(
@@ -19,7 +25,7 @@ export function PathLink({ to, children, className }: PathLinkProps) {
   );
 
   return (
-    <a href={to} className={className} onClick={handleClick}>
+    <a href={to} className={className} onClick={handleClick} {...restProps}>
       {children}
     </a>
   );

--- a/src/components/__tests__/PathLink.test.tsx
+++ b/src/components/__tests__/PathLink.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { createContext } from '../../mocks/context';
+import { PathLink } from '../PathLink';
+
+describe('PathLink', () => {
+  it('renders "data-" and "aria-" attributes passed as props', () => {
+    const { Component } = createContext();
+
+    const result = renderer.create(
+      <Component>
+        <PathLink
+          to='/path'
+          data-testid='test-data-attribute'
+          aria-label='test-aria-label'
+        >
+          test link
+        </PathLink>
+      </Component>,
+    );
+
+    const anchor = result.root.findByType('a');
+    expect(anchor.props['data-testid']).toBe('test-data-attribute');
+    expect(anchor.props['aria-label']).toBe('test-aria-label');
+  });
+});


### PR DESCRIPTION
This PR allows to pass custom `data-` and `aria-` attributes to the `PathLink` component`, which could be handy for testing, styling or accessibility.

```tsx
<PathLink to='/checkout' data-testid='checkout-button' aria-role='button'>
    Checkout
</PathLink>
```